### PR TITLE
Fix FAWE bug

### DIFF
--- a/src/main/java/net/countercraft/movecraft/repair/util/WEUtils.java
+++ b/src/main/java/net/countercraft/movecraft/repair/util/WEUtils.java
@@ -167,7 +167,10 @@ public class WEUtils {
 
             CompoundTag ct = (CompoundTag) t;
             String id = ct.getString("id");
-            BlockType type = new BlockType(id);
+            BlockType type = BlockTypes.get(id);
+            if (type == null) {
+                continue;
+            }
             Material material = BukkitAdapter.adapt(type);
 
             byte count = ct.getByte("Count");


### PR DESCRIPTION
I did some digging into it, and this was the part where FAWE didn't work at all. It seems that FAWE doesn't use this method at all because there seemed to already be some kind of method to get a BlockType from a string. Since FAWE almost all of worldedit's API still, I modified the code below so it works with FAWE.

This works with normal worldedit as well, tested this in my 1.16.5 server. 