### PR TITLE
Fixes/add #17

### DIFF
--- a/src/main/java/net/countercraft/movecraft/repair/MovecraftRepair.java
+++ b/src/main/java/net/countercraft/movecraft/repair/MovecraftRepair.java
@@ -211,6 +211,18 @@ public final class MovecraftRepair extends JavaPlugin {
                 throw new InvalidValueException("RepairLastPass entries must be a material name.");
             }
         }
+
+        entry = config.get("RepairBlackList");
+        if (!(entry instanceof  List)) {
+            throw  new InvalidValueException("RepairBlackList must be a list.");
+        }
+        for (Object object : (List<?>) entry) {
+            if (object instanceof String s) {
+                Config.RepairBlackList.addAll(Tags.parseMaterials(s));
+            } else {
+                throw new InvalidValueException("RepairBlackList entries must be a material name.");
+            }
+        }
     }
 
     @NotNull

--- a/src/main/java/net/countercraft/movecraft/repair/config/Config.java
+++ b/src/main/java/net/countercraft/movecraft/repair/config/Config.java
@@ -23,4 +23,5 @@ public class Config {
     public static Set<Material> RepairDropperItems = EnumSet.noneOf(Material.class);
     public static Set<Material> RepairFirstPass = EnumSet.noneOf(Material.class);
     public static Set<Material> RepairLastPass = EnumSet.noneOf(Material.class);
+    public static Set<Material> RepairBlackList = EnumSet.noneOf(Material.class);
 }

--- a/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import net.countercraft.movecraft.repair.config.Config;
 import net.countercraft.movecraft.util.hitboxes.BitmapHitBox;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -132,7 +133,7 @@ public class RepairState {
                         }
 
                         Material requiredMaterial = RepairUtils.remapMaterial(schematicMaterial);
-                        if (requiredMaterial == Material.AIR)
+                        if (requiredMaterial.isAir())
                             continue;
 
                         materials.add(RepairBlobManager.get(requiredMaterial), RepairUtils.blockCost(requiredMaterial));
@@ -155,7 +156,7 @@ public class RepairState {
                     hitBox.add(MathUtils.bukkit2MovecraftLoc(worldPosition));
                     for (Material m : inventoryRepair.getRight().getKeySet()) {
                         Material requiredMaterial = RepairUtils.remapMaterial(m);
-                        if (requiredMaterial == Material.AIR)
+                        if (requiredMaterial.isAir() || Config.RepairBlackList.contains(requiredMaterial))
                             continue;
 
                         materials.add(RepairBlobManager.get(requiredMaterial), inventoryRepair.getRight().get(m));

--- a/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
@@ -178,6 +178,9 @@ public class RepairState {
 
     private void addInventoryTasks(RepairQueue tasks, @Nullable BlockRepair blockRepair, Location location, @NotNull Counter<Material> counter) {
         for (Material m : counter.getKeySet()) {
+            if (Config.RepairBlackList.contains(m))
+                continue;
+
             ItemStack items = new ItemStack(m, counter.get(m));
             InventoryRepair inventoryRepair = new InventoryRepair(location, items);
             inventoryRepair.setDependency(blockRepair);

--- a/src/main/java/net/countercraft/movecraft/repair/util/RepairUtils.java
+++ b/src/main/java/net/countercraft/movecraft/repair/util/RepairUtils.java
@@ -169,6 +169,8 @@ public class RepairUtils {
     public static boolean needsBlockRepair(Material targetType, Material currentType) {
         if (targetType.isAir())
             return false;
+        if (Config.RepairBlackList.contains(targetType) || Config.RepairBlackList.contains(currentType))
+            return false;
 
         return targetType != currentType;
     }

--- a/src/main/java/net/countercraft/movecraft/repair/util/WarfareUtils.java
+++ b/src/main/java/net/countercraft/movecraft/repair/util/WarfareUtils.java
@@ -19,7 +19,6 @@ import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.processing.effects.Effect;
-import net.countercraft.movecraft.repair.config.Config;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -66,8 +65,6 @@ public class WarfareUtils {
                     if (material.isAir())
                         continue; // most blocks will be air, quickly move on to the next. This loop will run
                                   // millions of times and needs to be fast
-                    if (Config.RepairBlackList.contains(material))
-                        continue;
                     if (!world.getBlockAt(x, y, z).isEmpty() && !world.getBlockAt(x, y, z).isLiquid())
                         continue; // Don't replace blocks which aren't liquid or air
 

--- a/src/main/java/net/countercraft/movecraft/repair/util/WarfareUtils.java
+++ b/src/main/java/net/countercraft/movecraft/repair/util/WarfareUtils.java
@@ -19,6 +19,7 @@ import net.countercraft.movecraft.Movecraft;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.processing.WorldManager;
 import net.countercraft.movecraft.processing.effects.Effect;
+import net.countercraft.movecraft.repair.config.Config;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -65,6 +66,8 @@ public class WarfareUtils {
                     if (material.isAir())
                         continue; // most blocks will be air, quickly move on to the next. This loop will run
                                   // millions of times and needs to be fast
+                    if (Config.RepairBlackList.contains(material))
+                        continue;
                     if (!world.getBlockAt(x, y, z).isEmpty() && !world.getBlockAt(x, y, z).isLiquid())
                         continue; // Don't replace blocks which aren't liquid or air
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -48,4 +48,7 @@ RepairFirstPass: # First pass to construct a hull without heavy armor
 RepairLastPass:
  - "end_stone"
  - "end_stone_bricks"
+RepairBlackList:
+ - "bedrock"
+ - "barrier"
 # Observers are placed second to last (after RepairLastPass), with fragile blocks placed last.


### PR DESCRIPTION
Didn't test but this should do to fix the issue, this is also my first time working on Movecraft-Repair, I hope everything makes sense.

Added a config line for a list of materials to blacklist, this defaults to `bedrock` and `barrier` blocks, this `Set` is checked to make sure that those block types aren't saved in the schematics.