### PR TITLE
Rotate repair states based on the rotation of the sign

### DIFF
--- a/src/main/java/net/countercraft/movecraft/repair/RepairSign.java
+++ b/src/main/java/net/countercraft/movecraft/repair/RepairSign.java
@@ -123,10 +123,10 @@ public class RepairSign implements Listener {
             return;
         } catch (ProtoRepair.ItemRemovalException e) {
             player.sendMessage(I18nSupport.getInternationalisedComponent("Repair - Removal exception"));
-            return;
-        } catch (ProtoRepair.ProtoRepairExpiredException | ProtoRepair.ProtoRepairLocationException e) {
-            // Expired or wrong location, go back to first click
             // ItemRemovalException shouldn't happen, but go back to first click regardless
+            return;
+        } catch (ProtoRepair.ProtoRepairExpiredException | ProtoRepair.ProtoRepairLocationException | ProtoRepair.ProtoRepairRotationException e) {
+            // Expired, wrong location or rotation, go back to first click
             createProtoRepair(sign, uuid, player, craft);
             return;
         } catch (ProtoRepair.CancelledException e) {

--- a/src/main/java/net/countercraft/movecraft/repair/types/ProtoRepair.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/ProtoRepair.java
@@ -9,6 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.Container;
 import org.bukkit.block.Sign;
@@ -24,6 +25,7 @@ import net.countercraft.movecraft.repair.RepairBlobManager;
 import net.countercraft.movecraft.repair.config.Config;
 import net.countercraft.movecraft.repair.events.RepairPreStartedEvent;
 import net.countercraft.movecraft.repair.types.blobs.RepairBlob;
+import net.countercraft.movecraft.repair.util.RotationUtils;
 import net.countercraft.movecraft.util.Counter;
 import net.countercraft.movecraft.util.MathUtils;
 import net.countercraft.movecraft.util.Pair;
@@ -36,18 +38,20 @@ public class ProtoRepair {
     private final RepairCounter materials;
     private final int damagedBlockCount;
     private final MovecraftLocation origin;
+    private final BlockFace rotation;
     private final World world;
     private final HitBox hitBox;
     private final long calculationTime;
     private boolean valid;
 
     public ProtoRepair(UUID playerUUID, String name, RepairQueue queue, RepairCounter materials, int damagedBlockCount,
-            MovecraftLocation origin, World world, HitBox hitBox) {
+            MovecraftLocation origin, BlockFace rotation, World world, HitBox hitBox) {
         this.playerUUID = playerUUID;
         this.name = name;
         this.queue = queue;
         this.materials = materials;
         this.origin = origin;
+        this.rotation = rotation;
         this.world = world;
         this.hitBox = hitBox;
         this.damagedBlockCount = damagedBlockCount;
@@ -75,6 +79,10 @@ public class ProtoRepair {
         return origin;
     }
 
+    public BlockFace getRotation() {
+        return rotation;
+    }
+
     public World getWorld() {
         return world;
     }
@@ -95,6 +103,8 @@ public class ProtoRepair {
             throw new ProtoRepairExpiredException(); // Check for expired
         if (!origin.equals(MathUtils.bukkit2MovecraftLoc(sign.getLocation())))
             throw new ProtoRepairLocationException(); // Check for origin
+        if (!rotation.equals(RotationUtils.getRotation(sign.getBlockData())))
+            throw new ProtoRepairLocationException(); // Check for rotation
 
         // Check for balance
         double cost = 0;

--- a/src/main/java/net/countercraft/movecraft/repair/types/ProtoRepair.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/ProtoRepair.java
@@ -97,14 +97,14 @@ public class ProtoRepair {
 
     @NotNull
     public Repair execute(@NotNull Craft craft, Sign sign)
-            throws ProtoRepairExpiredException, ProtoRepairLocationException, ItemRemovalException,
-            NotEnoughItemsException, NotEnoughMoneyException {
+            throws ProtoRepairExpiredException, ProtoRepairLocationException, ProtoRepairRotationException,
+            ItemRemovalException, NotEnoughItemsException, NotEnoughMoneyException {
         if (isInvalid())
             throw new ProtoRepairExpiredException(); // Check for expired
         if (!origin.equals(MathUtils.bukkit2MovecraftLoc(sign.getLocation())))
             throw new ProtoRepairLocationException(); // Check for origin
         if (!rotation.equals(RotationUtils.getRotation(sign.getBlockData())))
-            throw new ProtoRepairLocationException(); // Check for rotation
+            throw new ProtoRepairRotationException(); // Check for rotation
 
         // Check for balance
         double cost = 0;
@@ -253,6 +253,9 @@ public class ProtoRepair {
     }
 
     public static class ProtoRepairLocationException extends IllegalStateException {
+    }
+
+    public static class ProtoRepairRotationException extends IllegalStateException {
     }
 
     public static class CancelledException extends IllegalStateException {

--- a/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
@@ -78,11 +78,7 @@ public class RepairState {
 
     @NotNull
     private Clipboard rotate(@NotNull Sign sign) throws WorldEditException {
-        BlockVector3 signPosition = BlockVector3.at(sign.getX(), sign.getY(), sign.getZ());
-
-        BlockVector3 offset = signPosition.subtract(schematicSignOffset);
-        BlockVector3 schematicSignPosition = signPosition.subtract(offset).add(schematicMinPos);
-        BaseBlock schematicSign = schematic.getFullBlock(schematicSignPosition);
+        BaseBlock schematicSign = schematic.getFullBlock(schematic.getOrigin());
         BlockFace schematicSignFacing = RotationUtils.getRotation(schematicSign);
 
         BlockFace worldSignFacing = RotationUtils.getRotation(sign.getBlock());

--- a/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
@@ -177,7 +177,7 @@ public class RepairState {
             }
         }
 
-        ProtoRepair result = new ProtoRepair(playerUUID, name, queue, materials, damagedBlockCount, MathUtils.bukkit2MovecraftLoc(sign.getLocation()), sign.getWorld(), hitBox);
+        ProtoRepair result = new ProtoRepair(playerUUID, name, queue, materials, damagedBlockCount, MathUtils.bukkit2MovecraftLoc(sign.getLocation()), RotationUtils.getRotation(sign.getBlockData()), sign.getWorld(), hitBox);
 
         ProtoRepairCreateEvent event = new ProtoRepairCreateEvent(result);
         Bukkit.getPluginManager().callEvent(event);

--- a/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
@@ -96,13 +96,14 @@ public class RepairState {
 
         // We use offsets from the sign (clipboard origin) to calculate actual coordinates
         // This is straightforward since we already know the position of the sign in both the schematic and the world
-        BlockVector3 minOffset = clipboard.getMinimumPoint().subtract(clipboard.getOrigin());
-        BlockVector3 maxOffset = clipboard.getMaximumPoint().subtract(clipboard.getOrigin());
+        BlockVector3 clipboardOrigin = clipboard.getOrigin();
+        BlockVector3 minOffset = clipboard.getMinimumPoint().subtract(clipboardOrigin);
+        BlockVector3 maxOffset = clipboard.getMaximumPoint().subtract(clipboardOrigin);
 
         for (int x = minOffset.x(); x <= maxOffset.x(); x++) {
             for (int z = minOffset.z(); z <= maxOffset.z(); z++) {
                 for (int y = minOffset.y(); y <= maxOffset.y(); y++) {
-                    BlockVector3 schematicPosition = clipboard.getOrigin().add(x, y, z);
+                    BlockVector3 schematicPosition = clipboardOrigin.add(x, y, z);
                     BaseBlock schematicBlock = clipboard.getFullBlock(schematicPosition);
                     Material schematicMaterial = BukkitAdapter.adapt(schematicBlock.getBlockType());
                     BlockData schematicData = BukkitAdapter.adapt(schematicBlock);

--- a/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
+++ b/src/main/java/net/countercraft/movecraft/repair/types/RepairState.java
@@ -72,10 +72,10 @@ public class RepairState {
 
     @NotNull
     private Clipboard rotate(@NotNull Sign sign) throws WorldEditException {
-        BaseBlock schematicSign = schematic.getFullBlock(schematic.getOrigin());
+        BlockData schematicSign = BukkitAdapter.adapt(schematic.getBlock(schematic.getOrigin()));
         BlockFace schematicSignFacing = RotationUtils.getRotation(schematicSign);
 
-        BlockFace worldSignFacing = RotationUtils.getRotation(sign.getBlock());
+        BlockFace worldSignFacing = RotationUtils.getRotation(sign.getBlockData());
 
         int angle = RotationUtils.angleBetweenBlockFaces(worldSignFacing, schematicSignFacing);
 

--- a/src/main/java/net/countercraft/movecraft/repair/util/RotationUtils.java
+++ b/src/main/java/net/countercraft/movecraft/repair/util/RotationUtils.java
@@ -2,11 +2,12 @@ package net.countercraft.movecraft.repair.util;
 
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.Rotatable;
 import org.jetbrains.annotations.Nullable;
 
-import com.sk89q.worldedit.util.Direction;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
 public class RotationUtils {
@@ -18,64 +19,7 @@ public class RotationUtils {
      */
     @Nullable
     public static BlockFace getRotation(BaseBlock block) {
-        for (var e : block.getStates().entrySet()) {
-            String key = e.getKey().getName();
-
-            if (key.equals("rotation")) {
-                // Applies to "floor" signs
-                switch ((int) e.getValue()) {
-                    case 0:
-                        return BlockFace.SOUTH;
-                    case 1:
-                        return BlockFace.SOUTH_SOUTH_WEST;
-                    case 2:
-                        return BlockFace.SOUTH_WEST;
-                    case 3:
-                        return BlockFace.WEST_SOUTH_WEST;
-                    case 4:
-                        return BlockFace.WEST;
-                    case 5:
-                        return BlockFace.WEST_NORTH_WEST;
-                    case 6:
-                        return BlockFace.NORTH_WEST;
-                    case 7:
-                        return BlockFace.NORTH_NORTH_WEST;
-                    case 8:
-                        return BlockFace.NORTH;
-                    case 9:
-                        return BlockFace.NORTH_NORTH_EAST;
-                    case 10:
-                        return BlockFace.NORTH_EAST;
-                    case 11:
-                        return BlockFace.EAST_NORTH_EAST;
-                    case 12:
-                        return BlockFace.EAST;
-                    case 13:
-                        return BlockFace.EAST_SOUTH_EAST;
-                    case 14:
-                        return BlockFace.SOUTH_EAST;
-                    case 15:
-                        return BlockFace.SOUTH_SOUTH_EAST;
-                    default:
-                        return null;
-                }
-            } else if (key.equals("facing")) {
-                // Applies to wall signs
-                switch ((Direction) e.getValue()) {
-                    case SOUTH:
-                        return BlockFace.SOUTH;
-                    case WEST:
-                        return BlockFace.WEST;
-                    case NORTH:
-                        return BlockFace.NORTH;
-                    case EAST:
-                        return BlockFace.EAST;
-                    default:
-                        return null;
-                }
-            }
-        }
-        return null;
+        return getRotation(BukkitAdapter.adapt(block));
     }
 
     /**
@@ -86,13 +30,24 @@ public class RotationUtils {
      */
     @Nullable
     public static BlockFace getRotation(Block block) {
-        if (block.getBlockData() instanceof Rotatable) {
+        return getRotation(block.getBlockData());
+    }
+
+    /**
+     * Get the rotation of a Spigot block data
+     * 
+     * @param blockData Block data to check
+     * @return Spigot BlockFace to represent the rotation
+     */
+    @Nullable
+    public static BlockFace getRotation(BlockData blockData) {
+        if (blockData instanceof Rotatable) {
             // Applies to "floor" signs
-            return ((Rotatable) block.getBlockData()).getRotation();
+            return ((Rotatable) blockData).getRotation();
         }
-        if (block.getBlockData() instanceof Directional) {
+        if (blockData instanceof Directional) {
             // Applies to wall signs
-            return ((Directional) block.getBlockData()).getFacing();
+            return ((Directional) blockData).getFacing();
         }
         return null;
     }

--- a/src/main/java/net/countercraft/movecraft/repair/util/RotationUtils.java
+++ b/src/main/java/net/countercraft/movecraft/repair/util/RotationUtils.java
@@ -6,6 +6,7 @@ import org.bukkit.block.data.Directional;
 import org.bukkit.block.data.Rotatable;
 import org.jetbrains.annotations.Nullable;
 
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.block.BaseBlock;
 
 public class RotationUtils {
@@ -18,44 +19,60 @@ public class RotationUtils {
     @Nullable
     public static BlockFace getRotation(BaseBlock block) {
         for (var e : block.getStates().entrySet()) {
-            if (!e.getKey().getName().equals("rotation"))
-                continue;
+            String key = e.getKey().getName();
 
-            switch ((int) e.getValue()) {
-                case 0:
-                    return BlockFace.SOUTH;
-                case 1:
-                    return BlockFace.SOUTH_SOUTH_WEST;
-                case 2:
-                    return BlockFace.SOUTH_WEST;
-                case 3:
-                    return BlockFace.WEST_SOUTH_WEST;
-                case 4:
-                    return BlockFace.WEST;
-                case 5:
-                    return BlockFace.WEST_NORTH_WEST;
-                case 6:
-                    return BlockFace.NORTH_WEST;
-                case 7:
-                    return BlockFace.NORTH_NORTH_WEST;
-                case 8:
-                    return BlockFace.NORTH;
-                case 9:
-                    return BlockFace.NORTH_NORTH_EAST;
-                case 10:
-                    return BlockFace.NORTH_EAST;
-                case 11:
-                    return BlockFace.EAST_NORTH_EAST;
-                case 12:
-                    return BlockFace.EAST;
-                case 13:
-                    return BlockFace.EAST_SOUTH_EAST;
-                case 14:
-                    return BlockFace.SOUTH_EAST;
-                case 15:
-                    return BlockFace.SOUTH_SOUTH_EAST;
-                default:
-                    return null;
+            if (key.equals("rotation")) {
+                // Applies to "floor" signs
+                switch ((int) e.getValue()) {
+                    case 0:
+                        return BlockFace.SOUTH;
+                    case 1:
+                        return BlockFace.SOUTH_SOUTH_WEST;
+                    case 2:
+                        return BlockFace.SOUTH_WEST;
+                    case 3:
+                        return BlockFace.WEST_SOUTH_WEST;
+                    case 4:
+                        return BlockFace.WEST;
+                    case 5:
+                        return BlockFace.WEST_NORTH_WEST;
+                    case 6:
+                        return BlockFace.NORTH_WEST;
+                    case 7:
+                        return BlockFace.NORTH_NORTH_WEST;
+                    case 8:
+                        return BlockFace.NORTH;
+                    case 9:
+                        return BlockFace.NORTH_NORTH_EAST;
+                    case 10:
+                        return BlockFace.NORTH_EAST;
+                    case 11:
+                        return BlockFace.EAST_NORTH_EAST;
+                    case 12:
+                        return BlockFace.EAST;
+                    case 13:
+                        return BlockFace.EAST_SOUTH_EAST;
+                    case 14:
+                        return BlockFace.SOUTH_EAST;
+                    case 15:
+                        return BlockFace.SOUTH_SOUTH_EAST;
+                    default:
+                        return null;
+                }
+            } else if (key.equals("facing")) {
+                // Applies to wall signs
+                switch ((Direction) e.getValue()) {
+                    case SOUTH:
+                        return BlockFace.SOUTH;
+                    case WEST:
+                        return BlockFace.WEST;
+                    case NORTH:
+                        return BlockFace.NORTH;
+                    case EAST:
+                        return BlockFace.EAST;
+                    default:
+                        return null;
+                }
             }
         }
         return null;
@@ -70,10 +87,12 @@ public class RotationUtils {
     @Nullable
     public static BlockFace getRotation(Block block) {
         if (block.getBlockData() instanceof Rotatable) {
+            // Applies to "floor" signs
             return ((Rotatable) block.getBlockData()).getRotation();
         }
         if (block.getBlockData() instanceof Directional) {
-            return ((Directional) block.getBlockData()).getFacing().getOppositeFace();
+            // Applies to wall signs
+            return ((Directional) block.getBlockData()).getFacing();
         }
         return null;
     }


### PR DESCRIPTION
This pull request allows crafts to be repaired regardless of their current orientation. Every possible placement of both wall signs and "floor" signs should work.

Note that it is no longer possible to precalculate schematic coordinates since the schematic will be rotated differently depending on the sign used.